### PR TITLE
[fix] correct disk in storage.xml

### DIFF
--- a/configs/clickhouse/config.d/storage.xml
+++ b/configs/clickhouse/config.d/storage.xml
@@ -9,7 +9,7 @@
       </minio>
       <s3_cache>
         <type>cache</type>
-        <disk>s3</disk>
+        <disk>minio</disk>
         <path>/tmp/</path>
         <max_size>1Gi</max_size>
       </s3_cache>


### PR DESCRIPTION
Error:
```
Application: Caught exception while loading metadata: Code: 36. DB::Exception:
Cannot wrap disk `s3` with cache layer `s3_cache`: there is no such disk (it should be initialized before cache disk).
(BAD_ARGUMENTS), Stack trace (when copying this message, always include the lines below):
```